### PR TITLE
pywinpty 2.0.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.5.7" %}
+{% set version = "2.0.10" %}
 
 package:
   name: pywinpty
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pywinpty/pywinpty-{{ version }}.tar.gz
-  sha256: 2d7e9c881638a72ffdca3f5417dd1563b60f603e1b43e5895674c2a1b01f95a0
+  sha256: cdbb5694cf8c7242c2ecfaca35c545d31fa5d5814c3d67a4e628f803f680ebea
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 5b7492e..6518f6d 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.5.7" %}
+{% set version = "2.0.10" %}
 
 package:
   name: pywinpty
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pywinpty/pywinpty-{{ version }}.tar.gz
-  sha256: 2d7e9c881638a72ffdca3f5417dd1563b60f603e1b43e5895674c2a1b01f95a0
+  sha256: cdbb5694cf8c7242c2ecfaca35c545d31fa5d5814c3d67a4e628f803f680ebea
 
 build:
   number: 0

```

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/spyder-ide/pywinpty/releases
[Diff between the latest and previous upstream releases](https://github.com/spyder-ide/pywinpty/compare/0.5.7...2.0.10)
Changelog: https://github.com/spyder-ide/pywinpty/blob/main/CHANGELOG.md
Requirements:
 *  pyproject.toml:  https://github.com/spyder-ide/pywinpty/blob/v2.0.10/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'win-64'
 * Latest version: 2.0.10
 * Release on PyPi:
    * version: 2.0.10
    * date: 2023-01-02T17:59:22
* [PyPi history](https://pypi.org/project/pywinpty/#history)
 * Popularity: 
    * 3 months downloads: 541675.0
    * All time:  1303734 downloads -  pywinpty  2.0.10  Pseudoterminals for Windows in Python  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
4. - [ ] Verify if the package needs `setuptools`
    
6. - [ ] Verify if the package needs `wheel`
    
8. - [ ] NO `pip` in test
    
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE.txt is present

15. - [ ] License family is NOT present
    
16. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/pywinpty-feedstock/recipe/meta.yaml
Dependencies: ['m2w64-gcc-libs', 'm2w64-toolchain', 'cython', 'winpty', 'python', 'libpython', 'pip']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:

</details>

**Package Build Score: 19**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/pywinpty-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/pywinpty-feedstock/tree/2.0.10)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/pywinpty)
* [Diff between upstream and feature branch](https://github.com/conda-forge/pywinpty-feedstock/compare/main...AnacondaRecipes:2.0.10)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/pywinpty-feedstock/compare/master...AnacondaRecipes:2.0.10)
* [The last merged PRs](https://github.com/AnacondaRecipes/pywinpty-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.0.10 git@github.com:AnacondaRecipes/pywinpty-feedstock.git
```
