### PR TITLE
Rebuild for Python 3.11

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -12,7 +12,7 @@ REM Check that all downstream libraries licenses are present
 set PATH=%PATH%;%CARGO_HOME%\bin
 cargo-license --json > dependencies.json
 cat dependencies.json
-python %RECIPE_DIR%\check_licenses.py
+%PYTHON% %RECIPE_DIR%\check_licenses.py
 REM Use PEP517 to install the package
 maturin build --release -i %PYTHON%
 REM Install wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,24 +9,26 @@ source:
   sha256: 20ec117183f79642eff555ce0dd1823f942618d65813fb6122d14b6e34b5d05a
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not win]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - clang
-    - llvm
+    - clangdev
     - rust
     - llvmdev
     - llvm-tools
     - libclang
     - maturin <=0.12.0
     - toml
-    - pip
     - winpty
   host:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - setuptools
+    - wheel
     - python
     - pip
     - winpty


### PR DESCRIPTION
Issue:
While building for Python 3.11 an error occurred while building:
```
dev-admin@EC2AMAZ-RJCE302 C:\Users\dev-admin\aggregate>conda-build --python=3.11 --numpy=1.22 --croot=c:/ci_311/ -c py311_bs/label/release --use-local --no-test ./pywinpty-feedstock   || echo "pywinpty-feedstock"
 1>>refailed.pywinpty  || cmd /K "exit /b 0"
Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from internal_defaults
Adding in variants from C:\Users\dev-admin\aggregate\conda_build_config.yaml
INFO:conda_build.variants:Adding in variants from C:\Users\dev-admin\aggregate\conda_build_config.yaml
Adding in variants from C:\Users\dev-admin\aggregate\pywinpty-feedstock\recipe\conda_build_config.yaml
INFO:conda_build.variants:Adding in variants from C:\Users\dev-admin\aggregate\pywinpty-feedstock\recipe\conda_build_config.yaml
Adding in variants from config.variant
INFO:conda_build.variants:Adding in variants from config.variant
Attempting to finalize metadata for pywinpty
INFO:conda_build.metadata:Attempting to finalize metadata for pywinpty
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
BUILD START: ['pywinpty-2.0.2-py311h5da7b33_0.tar.bz2']
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: c:\ci_311\pywinpty_1676936456512\_h_env


The following NEW packages will be INSTALLED:

    bzip2:           1.0.8-he774522_0          defaults
    ca-certificates: 2023.01.10-haa95532_0     file:///c:/ci_311
    certifi:         2022.12.7-py311haa95532_0 file:///c:/ci_311
    libffi:          3.4.2-hd77b12b_6          defaults
    openssl:         1.1.1t-h2bbff1b_0         file:///c:/ci_311
    pip:             22.3.1-py311haa95532_0    file:///c:/ci_311
    python:          3.11.0-h966fe2a_1         py311_bs/label/release
    setuptools:      65.5.0-py311haa95532_0    file:///c:/ci_311
    sqlite:          3.40.1-h2bbff1b_0         defaults
    tk:              8.6.12-h2bbff1b_0         defaults
    tzdata:          2022g-h04d1e81_0          defaults
    vc:              14.2-h21ff451_1           defaults
    vs2015_runtime:  14.27.29016-h5e58377_2    defaults
    wheel:           0.37.1-pyhd3eb1b0_0       py311_bs/label/release
    wincertstore:    0.2-py311haa95532_0       file:///c:/ci_311
    winpty:          0.4.3-4                   defaults
    xz:              5.2.10-h8cc25b3_1         defaults
    zlib:            1.2.13-h8cc25b3_0         defaults

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: c:\ci_311\pywinpty_1676936456512\_build_env


The following NEW packages will be INSTALLED:

    bzip2:                   1.0.8-he774522_0          defaults
    ca-certificates:         2023.01.10-haa95532_0     file:///c:/ci_311
    certifi:                 2022.12.7-py310haa95532_0 defaults
    clang:                   14.0.6-h44fa016_0         file:///c:/ci_311
    clang-14:                14.0.6-default_h84e4e4f_0 file:///c:/ci_311
    libclang:                14.0.6-default_hf4acfee_0 file:///c:/ci_311
    libclang-cpp:            14.0.6-default_h120b48b_0 file:///c:/ci_311
    libclang13:              14.0.6-default_h8992b79_0 file:///c:/ci_311
    libffi:                  3.4.2-hd77b12b_6          defaults
    libiconv:                1.16-h2bbff1b_2           defaults
    libllvm14:               14.0.6-h3cc63d6_1         file:///c:/ci_311
    libxml2:                 2.9.14-h0ad7f3c_0         defaults
    llvm:                    14.0.6-h69520b9_1         file:///c:/ci_311
    llvm-tools:              14.0.6-hbc40eef_1         file:///c:/ci_311
    llvmdev:                 14.0.6-h3cc63d6_1         file:///c:/ci_311
    m2w64-gcc-libgfortran:   5.3.0-6                   defaults
    m2w64-gcc-libs:          5.3.0-7                   defaults
    m2w64-gcc-libs-core:     5.3.0-7                   defaults
    m2w64-gmp:               6.1.0-2                   defaults
    m2w64-libwinpthread-git: 5.0.0.4634.697f757-2      defaults
    maturin:                 0.11.5-py310h1718810_1    defaults
    msys2-conda-epoch:       20160418-1                defaults
    openssl:                 1.1.1t-h2bbff1b_0         file:///c:/ci_311
    pip:                     22.3.1-py310haa95532_0    defaults
    python:                  3.10.9-h966fe2a_0         defaults
    rust:                    1.64.0-haa95532_0         defaults
    tk:                      8.6.12-h2bbff1b_0         defaults
    toml:                    0.10.2-pyhd3eb1b0_0       defaults
    tzdata:                  2022g-h04d1e81_0          defaults
    vc:                      14.2-h21ff451_1           defaults
    vs2015_runtime:          14.27.29016-h5e58377_2    defaults
    vs2019_win-64:           19.27.29111-ha89c4d3_2    defaults
    vswhere:                 2.8.4-haa95532_0          defaults
    wincertstore:            0.2-py310haa95532_2       defaults
    winpty:                  0.4.3-4                   defaults
    xz:                      5.2.10-h8cc25b3_1         defaults
    zlib:                    1.2.13-h8cc25b3_0         defaults

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
ERROR conda.core.link:_execute(745): An error occurred while installing package 'file:///c:/ci_311::libclang-14.0.6-default_hf4acfee_0'.
Rolling back transaction: ...working... done
Traceback (most recent call last):
  File "C:\miniconda3\Scripts\conda-build-script.py", line 10, in <module>
    sys.exit(main())
  File "C:\miniconda3\lib\site-packages\conda_build\cli\main_build.py", line 495, in main
    execute(sys.argv[1:])
  File "C:\miniconda3\lib\site-packages\conda_build\cli\main_build.py", line 475, in execute
    outputs = api.build(
  File "C:\miniconda3\lib\site-packages\conda_build\api.py", line 180, in build
    return build_tree(
  File "C:\miniconda3\lib\site-packages\conda_build\build.py", line 3097, in build_tree
    packages_from_this = build(metadata, stats,
  File "C:\miniconda3\lib\site-packages\conda_build\build.py", line 2126, in build
    create_build_envs(top_level_pkg, notest)
  File "C:\miniconda3\lib\site-packages\conda_build\build.py", line 2006, in create_build_envs
    environ.create_env(m.config.build_prefix, build_actions, env='build',
  File "C:\miniconda3\lib\site-packages\conda_build\environ.py", line 907, in create_env
    execute_actions(actions, index)
  File "C:\miniconda3\lib\site-packages\conda\common\io.py", line 84, in decorated
    return f(*args, **kwds)
  File "C:\miniconda3\lib\site-packages\conda\plan.py", line 318, in execute_actions
    execute_instructions(plan, index, verbose)
  File "C:\miniconda3\lib\site-packages\conda\plan.py", line 529, in execute_instructions
    cmd(state, arg)
  File "C:\miniconda3\lib\site-packages\conda\instructions.py", line 71, in UNLINKLINKTRANSACTION_CMD
    unlink_link_transaction.execute()
  File "C:\miniconda3\lib\site-packages\conda\core\link.py", line 286, in execute
    self._execute(
  File "C:\miniconda3\lib\site-packages\conda\core\link.py", line 761, in _execute
    raise CondaMultiError(
conda.CondaMultiError: [Errno 2] No such file or directory: 'C:\\miniconda3\\pkgs\\libclang-14.0.6-default_hf4acfee_0\\Library\\bin\\clang++.exe'
()
```

Changes:
- Revised build.bat
- Revised build section
- Revised host section