### PR TITLE
pywinpty 2.0.15 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,12 +31,18 @@ requirements:
     - {{ pin_compatible('winpty') }}
 
 test:
+  source_files:
+    - winpty/tests
+    - runtests.py
   imports:
     - winpty
   requires:
     - pip
+    - python
+    - pytest
   commands:
     - pip check
+    - python -m runtests
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,8 @@ test:
     - flaky
   commands:
     - pip check
-    - python -m runtests
+    # test_read - issues with encoding
+    - python -m runtests -k "not test_read"
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
 {% set version = "2.0.15" %}
+{% set name = "pywinpty" %}
 
 package:
-  name: pywinpty
+  name: {{ name }}
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,6 @@ requirements:
 test:
   source_files:
     - winpty/tests
-    - runtests.py
   imports:
     - winpty
   requires:
@@ -44,7 +43,7 @@ test:
   commands:
     - pip check
     # test_read - issues with encoding
-    - python -m runtests -k "not test_read"
+    - pytest -vv -k "not test_read" winpty/tests
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
-{% set version = "2.0.14" %}
+{% set version = "2.0.15" %}
 
 package:
   name: pywinpty
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/pywinpty/pywinpty-{{ version }}.tar.gz
-  sha256: 18bd9529e4a5daf2d9719aa17788ba6013e594ae94c5a0c27e83df3278b0660e
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 312cf39153a8736c617d45ce8b6ad6cd2107de121df91c455b10ce6bba7a39b2
 
 build:
   number: 0
-  skip: true  # [(not win) or py<38]
+  skip: true  # [(not win) or py<39]
   script: 
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     - cargo-bundle-licenses --format yaml --output "{{ SRC_DIR }}\THIRDPARTY.yml"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ test:
     - pip
     - python
     - pytest
+    - flaky
   commands:
     - pip check
     - python -m runtests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,19 +31,12 @@ requirements:
     - {{ pin_compatible('winpty') }}
 
 test:
-  source_files:
-    - winpty/tests
   imports:
     - winpty
   requires:
     - pip
-    - python
-    - pytest
-    - flaky
   commands:
     - pip check
-    # test_read - issues with encoding
-    - pytest -vv -k "not test_read" winpty/tests
 
 
 about:


### PR DESCRIPTION
pywinpty 2.0.15 

**Destination channel:** Default

### Links

- [PKG-7147]
- dev_url:        https://github.com/spyder-ide/pywinpty/tree/v2.0.15
- conda_forge:    https://github.com/conda-forge/pywinpty-feedstock
- pypi:           https://pypi.org/project/pywinpty/2.0.15
- pypi inspector: https://inspector.pypi.io/project/pywinpty/2.0.15

### Explanation of changes:

- new version number
- upstream tests passing locally


[PKG-7147]: https://anaconda.atlassian.net/browse/PKG-7147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ